### PR TITLE
feat: Update git log view with OS-specific fonts and diff coloring

### DIFF
--- a/src/app/toolmanager.cpp
+++ b/src/app/toolmanager.cpp
@@ -73,7 +73,7 @@ void ToolManager::onReadyReadStandardOutput()
     if (m_command.startsWith("git log")) {
         emit gitLogReady(m_process->readAllStandardOutput());
     } else {
-        emit outputReady(m_command, m_process->readAllStandardOutput(), m_branchName);
+        emit outputReady(m_command, formatDiffOutput(m_process->readAllStandardOutput()), m_branchName);
     }
 }
 
@@ -100,3 +100,20 @@ void ToolManager::onQmlFormatProcessFinished(int exitCode, QProcess::ExitStatus 
     }
 }
 
+QString ToolManager::formatDiffOutput(const QString &output) const
+{
+    QStringList lines = output.split('\n');
+    QString formattedOutput;
+    for (const QString &line : lines) {
+        QString escapedLine = line;
+        escapedLine.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;");
+        if (escapedLine.startsWith('+')) {
+            formattedOutput += "<font color=\"green\">" + escapedLine + "</font><br>";
+        } else if (escapedLine.startsWith('-')) {
+            formattedOutput += "<font color=\"red\">" + escapedLine + "</font><br>";
+        } else {
+            formattedOutput += escapedLine + "<br>";
+        }
+    }
+    return formattedOutput;
+}

--- a/src/app/toolmanager.h
+++ b/src/app/toolmanager.h
@@ -28,6 +28,7 @@ private slots:
     void onQmlFormatProcessFinished(int exitCode, QProcess::ExitStatus exitStatus);
 
 private:
+    QString formatDiffOutput(const QString &output) const;
     QProcess *m_branchProcess;
     QProcess *m_process;
     QProcess *m_qmlFormatProcess;

--- a/src/qml/GitOutputWindow.qml
+++ b/src/qml/GitOutputWindow.qml
@@ -35,6 +35,7 @@ Window {
                 Layout.fillHeight: true
                 model: gitLogModel
                 visible: gitLogModel !== null
+                clip: true
 
                 delegate: Component {
                     // Use Item as the root for better layout control.
@@ -67,7 +68,7 @@ Window {
                             // The main layout for all content, with internal padding.
                             ColumnLayout {
                                 id: column
-                                width: parent.width - 20
+                                width: parent.width - 40
                                 x: 10
                                 y: 10
                                 anchors.margins: 15 // Internal padding for all content
@@ -75,49 +76,14 @@ Window {
 
                                 // Header section with author, date, and expand indicator
                                 RowLayout {
-                                    width: parent.width
+
                                     anchors.margins: 15 // Internal padding for all content
 
-                                    height: childrenRect.height
-
-                                    // Author Name
-                                    Label {
-                                        text: model.authorName
-                                        font.bold: true
-                                        font.pixelSize: 16
-                                        color: "#2c3e50" // A dark, modern blue-gray
-                                        ToolTip.visible: authorMouseArea.containsMouse
-                                        ToolTip.text: model.authorName + " <" + model.authorEmail + ">"
-
-                                        MouseArea {
-                                            id: authorMouseArea
-                                            anchors.fill: parent
-                                            hoverEnabled: true
-                                        }
-                                    }
-
-                                    // Spacer to push the date to the right
-                                    Item {
-                                        Layout.fillWidth: true
-                                    }
-
-                                    // Date
-                                    Label {
-                                        text: model.date
-                                        font.pixelSize: 13
-                                        color: "#7f8c8d" // A muted gray for secondary info
-                                        ToolTip.visible: dateMouseArea.containsMouse
-                                        ToolTip.text: model.date + " " + model.time
-
-                                        MouseArea {
-                                            id: dateMouseArea
-                                            anchors.fill: parent
-                                            hoverEnabled: true
-                                        }
-                                    }
+                                    height: headline.implicitHeight
 
                                     // Expand/Collapse Indicator
                                     Label {
+                                        id: arrow
                                         text: "▶" // A simple arrow character
                                         font.pixelSize: 12
                                         color: "#7f8c8d"
@@ -133,17 +99,54 @@ Window {
                                                 }
                                             }
                                         }
+                                        width: implicitWidth
+                                    }
+
+                                    // Date
+                                    Label {
+                                        id: date
+                                        text: model.date
+                                        font.pixelSize: 13
+                                        color: "#7f8c8d" // A muted gray for secondary info
+                                        ToolTip.visible: dateMouseArea.containsMouse
+                                        ToolTip.text: model.date + " " + model.time
+                                        width: implicitWidth
+
+                                        MouseArea {
+                                            id: dateMouseArea
+                                            anchors.fill: parent
+                                            hoverEnabled: true
+                                        }
+                                    }
+
+                                    // Header
+                                    Label {
+                                        id: headline
+                                        text: model.messageHeader
+                                        font.bold: true
+                                        font.pixelSize: 16
+                                        color: "#2c3e50" // A dark, modern blue-gray
+                                        elide: Text.ElideRight
+                                        width: background.width - arrow.width - date.width - 40
                                     }
                                 }
 
                                 // Commit Message Header
                                 Label {
                                     id: commit
-                                    text: model.messageHeader
-                                    width: parent.width
+                                    text: model.authorName
+                                    width: implicitWidth
+                                    font.pixelSize: 13
+                                    color: "#7f8c8d" // A muted gray for secondary info
                                     wrapMode: Text.WordWrap
-                                    font.pixelSize: 15
-                                    color: "#34495e" // Slightly softer than the author name
+                                    ToolTip.visible: authorMouseArea.containsMouse
+                                    ToolTip.text: model.authorName + " <" + model.authorEmail + ">"
+
+                                    MouseArea {
+                                        id: authorMouseArea
+                                        anchors.fill: parent
+                                        hoverEnabled: true
+                                    }
                                 }
 
                                 // --- Key Improvement: Animated Expandable Section ---
@@ -183,7 +186,7 @@ Window {
 
                                     // Divider line for visual separation
                                     Rectangle {
-                                        width: parent.width
+                                        width: background.width - 20
                                         height: 1
                                         color: "#e0e0e0"
                                         Layout.bottomMargin: 5
@@ -191,10 +194,20 @@ Window {
 
                                     // Full Commit Message Body
                                     Label {
+                                        id: messageBody
                                         text: model.messageBody
-                                        width: parent.width
+                                        Layout.preferredWidth: background.width - 20
                                         wrapMode: Text.WordWrap
+                                        textFormat: Text.PlainText
                                         color: "#34495e"
+                                    }
+
+                                    // Divider line for visual separation
+                                    Rectangle {
+                                        width: background.width - 20
+                                        height: 1
+                                        color: "#e0e0e0"
+                                        Layout.bottomMargin: 5
                                     }
 
                                     // Commit SHA

--- a/src/qml/GitOutputWindow.qml
+++ b/src/qml/GitOutputWindow.qml
@@ -227,7 +227,8 @@ Window {
                     readOnly: true
                     text: output
                     wrapMode: Text.NoWrap
-                    font.family: "monospace"
+                    font.family: Qt.platform.os === 'osx' ? 'Menlo' : 'Noto Sans Mono'
+                    textFormat: Text.RichText
                 }
             }
 

--- a/tests/test_toolmanager.cpp
+++ b/tests/test_toolmanager.cpp
@@ -14,5 +14,5 @@ void TestToolManager::testRunCommand()
     QCOMPARE(spy.count(), 1);
     QList<QVariant> arguments = spy.takeFirst();
     QCOMPARE(arguments.at(0).toString(), "echo hello");
-    QCOMPARE(arguments.at(1).toString().trimmed(), "hello");
+    QCOMPARE(arguments.at(1).toString(), "hello<br><br>");
 }


### PR DESCRIPTION
- Set the font to "Menlo" on macOS and "Noto Sans Mono" on Linux in the git log view.
- Color lines in the diff view: green for additions (`+`) and red for deletions (`-`).
- Updated the QML view to support rich text for diff coloring.
- Adjusted unit tests to match the new HTML-formatted output.