### PR TITLE
🧹 Simplify verbose theme fallback logic

### DIFF
--- a/qml/ai/OutputPane.qml
+++ b/qml/ai/OutputPane.qml
@@ -40,7 +40,6 @@ Follow the instructions by user. You will get a full file content and user selec
 
     PariPaperWell {
         id: aiOutputWell
-        isDark: aiPane.isDark
         Layout.fillHeight: true
         
         StackLayout {

--- a/qml/common/PariButton.qml
+++ b/qml/common/PariButton.qml
@@ -1,6 +1,7 @@
 import QtQuick
 import QtQuick.Controls
 import QtQuick.Controls.Basic
+import "../app"
 
 AbstractButton {
     id: control
@@ -10,15 +11,18 @@ AbstractButton {
     
     property bool highlighted: false
     
-    // Use pariTheme if available, otherwise fallback to appSettings (for tests)
-    readonly property bool _isDark: (typeof pariTheme !== 'undefined') ? pariTheme.isDark : ((typeof appSettings !== 'undefined' && appSettings !== null) ? appSettings.systemThemeIsDark : false)
+    // Use pariTheme if available, otherwise fallback to a local PariTheme instance (for tests)
+    readonly property var _theme: (typeof pariTheme !== 'undefined') ? pariTheme : fallbackTheme
+    PariTheme { id: fallbackTheme }
+
+    readonly property bool _isDark: _theme.isDark
 
     contentItem: Label {
         text: control.text
-        font.pixelSize: (typeof pariTheme !== 'undefined') ? pariTheme.fontButton : 13
+        font.pixelSize: _theme.fontButton
         color: {
-            if (control.highlighted) return (typeof pariTheme !== 'undefined') ? pariTheme.textColorInverse : "#ffffff";
-            return _isDark ? (typeof pariTheme !== 'undefined' ? pariTheme.textColorInverse : "#ffffff") : (typeof pariTheme !== 'undefined' ? pariTheme.textColor : "#000000");
+            if (control.highlighted) return _theme.textColorInverse;
+            return _isDark ? _theme.textColorInverse : _theme.textColor;
         }
         horizontalAlignment: Text.AlignHCenter
         verticalAlignment: Text.AlignVCenter
@@ -26,13 +30,13 @@ AbstractButton {
     }
 
     background: Rectangle {
-        radius: (typeof pariTheme !== 'undefined') ? pariTheme.borderRadius : 4
+        radius: _theme.borderRadius
         border.width: 1
         border.color: {
             if (control.highlighted) {
-                return _isDark ? (typeof pariTheme !== 'undefined' ? pariTheme.accentColor : "#0d4d92") : (typeof pariTheme !== 'undefined' ? pariTheme.accentColor : "#2a8bf2");
+                return _theme.accentColor;
             }
-            return (typeof pariTheme !== 'undefined') ? pariTheme.sidebarBorder : (_isDark ? "#111111" : "#9b9b9b");
+            return _theme.sidebarBorder;
         }
         
         gradient: Gradient {
@@ -44,10 +48,10 @@ AbstractButton {
                         return _isDark ? "#1a1a1a" : "#c0c0c0";
                     }
                     if (control.highlighted) {
-                        return (typeof pariTheme !== 'undefined') ? (_isDark ? pariTheme.btnDarkPrimaryTop : pariTheme.btnLightPrimaryTop) : (_isDark ? "#1a6ac3" : "#3b99fc");
+                        return _isDark ? _theme.btnDarkPrimaryTop : _theme.btnLightPrimaryTop;
                     }
                     if (control.hovered) return _isDark ? "#4a4a4a" : "#fdfdfd";
-                    return (typeof pariTheme !== 'undefined') ? (_isDark ? pariTheme.btnDarkTop : pariTheme.btnLightTop) : (_isDark ? "#3c3c3c" : "#f0f0f0");
+                    return _isDark ? _theme.btnDarkTop : _theme.btnLightTop;
                 }
             }
             GradientStop { 
@@ -58,10 +62,10 @@ AbstractButton {
                         return _isDark ? "#000000" : "#a0a0a0";
                     }
                     if (control.highlighted) {
-                        return (typeof pariTheme !== 'undefined') ? (_isDark ? pariTheme.btnDarkPrimaryBottom : pariTheme.btnLightPrimaryBottom) : (_isDark ? "#0d4d92" : "#0078d7");
+                        return _isDark ? _theme.btnDarkPrimaryBottom : _theme.btnLightPrimaryBottom;
                     }
                     if (control.hovered) return _isDark ? "#2a2a2a" : "#d0d0d0";
-                    return (typeof pariTheme !== 'undefined') ? (_isDark ? pariTheme.btnDarkBottom : pariTheme.btnLightBottom) : (_isDark ? "#252525" : "#cccccc");
+                    return _isDark ? _theme.btnDarkBottom : _theme.btnLightBottom;
                 }
             }
         }

--- a/qml/common/PariPaperWell.qml
+++ b/qml/common/PariPaperWell.qml
@@ -1,21 +1,23 @@
 import QtQuick
 import QtQuick.Layouts
+import "../app"
 
 Rectangle {
     id: root
     
-    // Fallback to appSettings only if pariTheme is not available (e.g. in standalone tests)
-    readonly property bool _isDark: (typeof pariTheme !== 'undefined') ? pariTheme.isDark : ((typeof appSettings !== 'undefined' && appSettings !== null) ? appSettings.systemThemeIsDark : false)
-    
-    property bool isDark: _isDark
+    // Use pariTheme if available, otherwise fallback to a local PariTheme instance (for tests)
+    readonly property var _theme: (typeof pariTheme !== 'undefined') ? pariTheme : fallbackTheme
+    PariTheme { id: fallbackTheme }
+
+    readonly property bool isDark: _theme.isDark
     property alias content: container.data
 
     Layout.fillWidth: true
-    Layout.margins: (typeof pariTheme !== 'undefined') ? pariTheme.paddingSmall : 4
-    radius: (typeof pariTheme !== 'undefined') ? pariTheme.borderRadius : 2
+    Layout.margins: _theme.paddingSmall
+    radius: _theme.borderRadius
     
-    color: (typeof pariTheme !== 'undefined') ? (isDirtyWell ? pariTheme.editorBgDirty : pariTheme.editorBg) : (isDark ? "#1a1a1a" : "#ffffff")
-    border.color: (typeof pariTheme !== 'undefined') ? pariTheme.editorBorder : (isDark ? "#121212" : "#bcbcbc")
+    color: isDirtyWell ? _theme.editorBgDirty : _theme.editorBg
+    border.color: _theme.editorBorder
     border.width: 1
 
     property bool isDirtyWell: false

--- a/qml/common/PariReadOnlyTextArea.qml
+++ b/qml/common/PariReadOnlyTextArea.qml
@@ -1,6 +1,7 @@
 import QtQuick
 import QtQuick.Controls
 import QtQuick.Controls.Basic
+import "../app"
 
 ScrollView {
     id: root
@@ -13,7 +14,11 @@ ScrollView {
     property alias textAreaFont: textArea.font
     property alias color: textArea.color
 
-    readonly property bool isDark: (typeof pariTheme !== 'undefined') ? pariTheme.isDark : ((typeof appSettings !== 'undefined' && appSettings !== null) ? appSettings.systemThemeIsDark : false)
+    // Use pariTheme if available, otherwise fallback to a local PariTheme instance (for tests)
+    readonly property var _theme: (typeof pariTheme !== 'undefined') ? pariTheme : fallbackTheme
+    PariTheme { id: fallbackTheme }
+
+    readonly property bool isDark: _theme.isDark
 
     TextArea {
         id: textArea
@@ -21,10 +26,10 @@ ScrollView {
         readOnly: true
         wrapMode: Text.WordWrap
         textFormat: root.textFormat
-        font.family: (typeof pariTheme !== 'undefined') ? pariTheme.monoFont : ((typeof appSettings !== 'undefined' && appSettings && appSettings.fontFamily) ? appSettings.fontFamily : "Menlo")
-        font.pointSize: (typeof pariTheme !== 'undefined') ? pariTheme.fontSize : ((typeof appSettings !== 'undefined' && appSettings && appSettings.fontSize) ? appSettings.fontSize : 12)
-        color: (typeof pariTheme !== 'undefined') ? pariTheme.textColor : (isDark ? "#d0d0d0" : "#1a1c1c")
-        padding: (typeof pariTheme !== 'undefined') ? pariTheme.paddingLarge : 10
+        font.family: _theme.monoFont
+        font.pointSize: _theme.fontSize
+        color: _theme.textColor
+        padding: _theme.paddingLarge
         background: Rectangle {
             color: "transparent"
         }

--- a/qml/common/PariTabBar.qml
+++ b/qml/common/PariTabBar.qml
@@ -2,6 +2,7 @@
 import QtQuick
 import QtQuick.Layouts
 import QtQuick.Controls
+import "../app"
 
 Rectangle {
     id: root
@@ -12,6 +13,10 @@ Rectangle {
     property int indicatorHeight: 3
     property double activeHeaderX : currentIndex * activeHeaderWidth
     property double activeHeaderWidth : 0.0
+
+    // Use pariTheme if available, otherwise fallback to a local PariTheme instance (for tests)
+    readonly property var _theme: (typeof pariTheme !== 'undefined') ? pariTheme : fallbackTheme
+    PariTheme { id: fallbackTheme }
 
     // Signal emitted when a tab is clicked
     signal tabClicked(int index)
@@ -111,7 +116,7 @@ Rectangle {
                     text: modelData.isDirty? modelData.fileName +  "- ✏️ Edited" : modelData.fileName
                     anchors.centerIn: parent
                     font.bold: root.currentIndex === index
-                    font.pixelSize: (typeof pariTheme !== 'undefined') ? pariTheme.fontToolbar : 11
+                    font.pixelSize: _theme.fontToolbar
                     // Active text uses the system highlight color, inactive uses standard text color
                     color: palette.text
                 }

--- a/qml/common/PariToolButton.qml
+++ b/qml/common/PariToolButton.qml
@@ -1,6 +1,7 @@
 import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
+import "../app"
 
 AbstractButton {
     id: control
@@ -12,7 +13,11 @@ AbstractButton {
     text: action ? action.text : ""
     iconSource: action ? action.iconSource : ""
     
-    readonly property bool isDark: appSettings.systemThemeIsDark
+    // Use pariTheme if available, otherwise fallback to a local PariTheme instance (for tests)
+    readonly property var _theme: (typeof pariTheme !== 'undefined') ? pariTheme : fallbackTheme
+    PariTheme { id: fallbackTheme }
+
+    readonly property bool isDark: _theme.isDark
     
     implicitWidth: 56
     implicitHeight: 56
@@ -33,7 +38,7 @@ AbstractButton {
         Label {
             Layout.alignment: Qt.AlignHCenter
             text: control.text
-            font.pixelSize: (typeof pariTheme !== 'undefined') ? pariTheme.fontToolbar : 11
+            font.pixelSize: _theme.fontToolbar
             color: {
                 if (control.isPrimary) return "#ffffff";
                 if (control.checked) return control.isDark ? "#4aa9ff" : "#0051a6";

--- a/qml/editor/CodeEditorPane.qml
+++ b/qml/editor/CodeEditorPane.qml
@@ -122,7 +122,6 @@ ColumnLayout {
     }
 
     PariPaperWell {
-        isDark: root.isDark 
         Layout.fillHeight: true
         isDirtyWell: root.dirty
         

--- a/qml/git/GitOutputWindow.qml
+++ b/qml/git/GitOutputWindow.qml
@@ -56,7 +56,6 @@ Window {
 
             PariPaperWell {
                 id: well
-                isDark: gitOutputWindow.isDark
                 Layout.fillHeight: true
                 
                 StackLayout {


### PR DESCRIPTION
The verbose and duplicated theme fallback logic in several common QML components has been refactored. A standardized pattern using a local `_theme` property with a fallback `PariTheme` instance was implemented, significantly reducing code complexity and improving readability. Consistent application of this pattern across the `qml/common/` directory ensures a cleaner codebase. Redundant property overrides in parent components were also removed as they are no longer necessary. Verification was performed using the existing UI test suite.

---
*PR created automatically by Jules for task [10457430971018167062](https://jules.google.com/task/10457430971018167062) started by @veskuh*