### PR TITLE
🧹 Fix variable shadowing in ShellSyntaxHighlighter

### DIFF
--- a/src/formatting/shellsyntaxhighlighter.cpp
+++ b/src/formatting/shellsyntaxhighlighter.cpp
@@ -1,24 +1,20 @@
 #include "shellsyntaxhighlighter.h"
+#include "syntaxtheme.h"
 
 ShellSyntaxHighlighter::ShellSyntaxHighlighter(QTextDocument *parent, SyntaxTheme *theme)
-    : QSyntaxHighlighter(parent), m_theme(theme)
-{
+    : QSyntaxHighlighter(parent), m_theme(theme) {
+    if (m_theme) {
+        commentFormat.setForeground(m_theme->commentColor);
+        stringFormat.setForeground(m_theme->stringColor);
+    }
 }
 
-void ShellSyntaxHighlighter::highlightBlock(const QString &text)
-{
-    if (!m_theme) return;
+void ShellSyntaxHighlighter::highlightBlock(const QString &text) {
+    if (!m_theme)
+        return;
 
-    QTextCharFormat commentFormat;
-    commentFormat.setForeground(m_theme->commentColor);
-
-    QTextCharFormat stringFormat;
-    stringFormat.setForeground(m_theme->stringColor);
-
-    QRegularExpression expression(
-        "(?<string>\"([^\"\\\\]|\\\\.)*\"|'[^']*')|"
-        "(?<comment>#[^\n]*)"
-    );
+    QRegularExpression expression("(?<string>\"([^\"\\\\]|\\\\.)*\"|'[^']*')|"
+                                  "(?<comment>#[^\n]*)");
 
     QRegularExpressionMatchIterator it = expression.globalMatch(text);
     while (it.hasNext()) {


### PR DESCRIPTION
Addresses the variable shadowing reported by Cppcheck in `ShellSyntaxHighlighter`. By removing the local type declarations in `highlightBlock` and moving initialization to the constructor, the code now correctly utilizes class members and avoids redundant per-block setup.

---
*PR created automatically by Jules for task [7630517372012415474](https://jules.google.com/task/7630517372012415474) started by @veskuh*