### PR TITLE
fix(build): install Kaakao libraries and QML module into app bundle

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,13 @@
 cmake_minimum_required(VERSION 3.16)
 project(Pari LANGUAGES CXX)
 
+if(APPLE)
+    if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT OR CMAKE_INSTALL_PREFIX STREQUAL "/usr/local")
+        set(CMAKE_INSTALL_PREFIX "/Applications" CACHE PATH "Install path prefix" FORCE)
+    endif()
+endif()
+
+
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTORCC ON)
 set(CMAKE_AUTOUIC ON) 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -118,18 +118,38 @@ endif()
 include(GNUInstallDirs)
 
 if(APPLE)
-    # On macOS, install the .app bundle to /Applications by default
-    # but respect CMAKE_INSTALL_PREFIX if set (e.g. /usr/local)
+
     install(TARGETS pari
-        BUNDLE DESTINATION /Applications
+        BUNDLE DESTINATION .
         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    )
+    install(TARGETS Kaakao Kaakaoplugin
+        LIBRARY DESTINATION pari.app/Contents/Frameworks
+        RUNTIME DESTINATION pari.app/Contents/Frameworks
+    )
+    if(NOT DEFINED QT_QML_OUTPUT_DIRECTORY)
+        set(QT_QML_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/qml")
+    endif()
+    install(DIRECTORY "${QT_QML_OUTPUT_DIRECTORY}/Kaakao"
+        DESTINATION pari.app/Contents/qml
     )
 else()
     # LINUX DEPLOYMENT
-    # 1. Install Binary (Force fresh install by being explicit)
+    # 1. Install Binary and Kaakao Libraries
     install(TARGETS pari
         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
         COMPONENT Application
+    )
+    install(TARGETS Kaakao Kaakaoplugin
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    )
+    if(NOT DEFINED QT_QML_OUTPUT_DIRECTORY)
+        set(QT_QML_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/qml")
+    endif()
+    install(DIRECTORY "${QT_QML_OUTPUT_DIRECTORY}/Kaakao"
+        DESTINATION qml
     )
 
     # 2. Install Icon
@@ -145,3 +165,4 @@ else()
         COMPONENT Application
     )
 endif()
+


### PR DESCRIPTION
Fixes issue where cmake --install build failed to bundle Kaakao dynamic libraries and QML module into pari.app.