### PR TITLE
feat(blame): add line numbers to git blame view

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -169,7 +169,7 @@ Pruned dead `btnLight*` and `btnDark*` properties from `PariTheme.qml`; updated 
 ## Step 10 — Line numbers in git blame view ✅
 
 **Status: DONE**
-Added lineNumbers to GitBlameModel (C++ model) and a line number gutter to the blame view delegate in GitOutputWindow.qml.
+Added lineNumbers to GitBlameModel (C++ model) and a line number gutter to the blame view delegate in GitOutputWindow.qml. OpenCode review fix round completed: initialized `lineNumber` and `showMetadata` in `BlameLine` struct to prevent undefined behavior, and added edge-case test coverage for invalid/empty model states.
 
 ---
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -166,6 +166,11 @@ Sourced `PariPaperWell` background and inner shadow directly from `Theme.content
 
 Pruned dead `btnLight*` and `btnDark*` properties from `PariTheme.qml`; updated `DESIGN.md`, `project.md`, and `README.md` to reflect Kaakao design system integration and submodules. Full build, `tst_all`, `tst_ui` (132 test cases), `--selfcheck`, and coverage report (87.4% line coverage) passed cleanly.
 
+## Step 10 — Line numbers in git blame view ✅
+
+**Status: DONE**
+Added lineNumbers to GitBlameModel (C++ model) and a line number gutter to the blame view delegate in GitOutputWindow.qml.
+
 ---
 
 ## Risks

--- a/qml/git/GitOutputWindow.qml
+++ b/qml/git/GitOutputWindow.qml
@@ -201,6 +201,30 @@ Window {
                                     color: model.color
                                 }
 
+                                Rectangle {
+                                    Layout.preferredWidth: 50
+                                    Layout.fillHeight: true
+                                    color: isDark ? "#252526" : "#f5f5f5"
+
+                                    KaakaoLabel {
+                                        anchors.fill: parent
+                                        anchors.rightMargin: 8
+                                        text: (typeof model.lineNumber !== "undefined" && model.lineNumber !== null) ? model.lineNumber : 0
+                                        font.family: Qt.platform.os === 'osx' ? 'Menlo' : 'Noto Sans Mono'
+                                        font.pointSize: appSettings.fontSize - 1
+                                        color: isDark ? "#888888" : "#666666"
+                                        horizontalAlignment: Text.AlignRight
+                                        verticalAlignment: Text.AlignVCenter
+                                    }
+
+                                    Rectangle {
+                                        anchors.right: parent.right
+                                        width: 1
+                                        height: parent.height
+                                        color: isDark ? "#3c3c3c" : "#e0e0e0"
+                                    }
+                                }
+
                                 Item {
                                     Layout.preferredWidth: 280
                                     Layout.fillHeight: true

--- a/src/integrations/gitblamemodel.cpp
+++ b/src/integrations/gitblamemodel.cpp
@@ -31,6 +31,7 @@ QVariant GitBlameModel::data(const QModelIndex &index, int role) const
     case ContentRole: return line.content;
     case ColorRole: return line.color;
     case ShowMetadataRole: return line.showMetadata;
+    case LineNumberRole: return line.lineNumber;
     default: return QVariant();
     }
 }
@@ -45,6 +46,7 @@ QHash<int, QByteArray> GitBlameModel::roleNames() const
     roles[ContentRole] = "content";
     roles[ColorRole] = "color";
     roles[ShowMetadataRole] = "showMetadata";
+    roles[LineNumberRole] = "lineNumber";
     return roles;
 }
 
@@ -72,6 +74,7 @@ void GitBlameModel::parseRawOutput(const QString &rawOutput)
     QStringList lines = rawOutput.split('\n');
     BlameLine currentLine;
     QString lastHash;
+    int lineCounter = 0;
     
     struct CommitInfo {
         QString author;
@@ -86,6 +89,8 @@ void GitBlameModel::parseRawOutput(const QString &rawOutput)
 
         if (line.startsWith('\t')) {
             // This is the actual source code line
+            ++lineCounter;
+            currentLine.lineNumber = lineCounter;
             currentLine.content = line.mid(1);
             currentLine.color = getColorForHash(currentLine.hash);
             currentLine.showMetadata = (currentLine.hash != lastHash);

--- a/src/integrations/gitblamemodel.h
+++ b/src/integrations/gitblamemodel.h
@@ -13,6 +13,7 @@ struct BlameLine {
     QString content;
     QColor color;
     bool showMetadata;
+    int lineNumber;
 };
 
 class GitBlameModel : public QAbstractListModel
@@ -26,7 +27,8 @@ public:
         DateRole,
         ContentRole,
         ColorRole,
-        ShowMetadataRole
+        ShowMetadataRole,
+        LineNumberRole
     };
 
     explicit GitBlameModel(QObject *parent = nullptr);

--- a/src/integrations/gitblamemodel.h
+++ b/src/integrations/gitblamemodel.h
@@ -12,8 +12,8 @@ struct BlameLine {
     QString date;
     QString content;
     QColor color;
-    bool showMetadata;
-    int lineNumber;
+    bool showMetadata = false;
+    int lineNumber = 0;
 };
 
 class GitBlameModel : public QAbstractListModel

--- a/tests/test_gitblamemodel.cpp
+++ b/tests/test_gitblamemodel.cpp
@@ -36,10 +36,18 @@ void TestGitBlameModel::testParsing() {
 
 void TestGitBlameModel::testClear() {
     GitBlameModel model;
+    QCOMPARE(model.rowCount(), 0);
+    QCOMPARE(model.data(model.index(0), GitBlameModel::LineNumberRole).toInt(), 0);
+
     model.parseRawOutput("4a9e0123456789abcdef0123456789abcdef0123 1 1 1\nauthor X\n\tcontent\n");
     QVERIFY(model.rowCount() > 0);
     model.clear();
     QCOMPARE(model.rowCount(), 0);
+    QCOMPARE(model.data(model.index(0), GitBlameModel::LineNumberRole).toInt(), 0);
+
+    model.parseRawOutput("");
+    QCOMPARE(model.rowCount(), 0);
+    QCOMPARE(model.data(model.index(0), GitBlameModel::LineNumberRole).toInt(), 0);
 }
 
 void TestGitBlameModel::cleanupTestCase() {}

--- a/tests/test_gitblamemodel.cpp
+++ b/tests/test_gitblamemodel.cpp
@@ -26,10 +26,12 @@ void TestGitBlameModel::testParsing() {
     QCOMPARE(model.data(model.index(0), GitBlameModel::DateRole).toString(), "2024-04-19");
     QCOMPARE(model.data(model.index(0), GitBlameModel::ContentRole).toString(), "#include <iostream>");
     QCOMPARE(model.data(model.index(0), GitBlameModel::ShowMetadataRole).toBool(), true);
+    QCOMPARE(model.data(model.index(0), GitBlameModel::LineNumberRole).toInt(), 1);
     
     // Check second line (same hash, metadata should be hidden)
     QCOMPARE(model.data(model.index(1), GitBlameModel::ContentRole).toString(), "int main() {");
     QCOMPARE(model.data(model.index(1), GitBlameModel::ShowMetadataRole).toBool(), false);
+    QCOMPARE(model.data(model.index(1), GitBlameModel::LineNumberRole).toInt(), 2);
 }
 
 void TestGitBlameModel::testClear() {


### PR DESCRIPTION
## Summary

Adds line numbers to the git blame view in the Git Output window. Each blamed line now shows a line number gutter (50px, monospace, right-aligned) between the commit color stripe and the metadata/code area.

## Changes

- **`src/integrations/gitblamemodel.h`** — Added `int lineNumber` field to `BlameLine` struct, `LineNumberRole` enum value, default initializers for `lineNumber` and `showMetadata`
- **`src/integrations/gitblamemodel.cpp`** — Increments counter per parsed line, exposes `lineNumber` role via `data()` and `roleNames()`
- **`qml/git/GitOutputWindow.qml`** — New 50px gutter column with dark/light theme styling (`#252526`/`#f5f5f5` background, `#3c3c3c`/`#e0e0e0` border)
- **`tests/test_gitblamemodel.cpp`** — Assertions for line numbers in `testParsing()` + edge-case checks in `testClear()`
- **`PLAN.md`** — Documented Step 10

## Verification

- [x] Builds clean (`cmake -B build && cmake --build build -- -j1`)
- [x] `tst_all` passes
- [x] OpenCode review: PASS